### PR TITLE
Remove Deprecated Push Event

### DIFF
--- a/AppDirectEvent.php
+++ b/AppDirectEvent.php
@@ -101,20 +101,6 @@ class AppDirectEvent extends AppDirectBase
 		return $event;
 	}
 	
-	public function postUserListChange($accountIdentifier)
-	{
-		$endpoint = 'events/';
-		
-		$xmlData = new SimpleXMLElement('<event></event>');
-		$xmlData->addChild('type', USER_LIST_CHANGE);
-		$xmlData->addChild('payload');
-		$xmlData->payload->addChild('account');
-		$xmlData->payload->account->addChild('accountIdentifier', $accountIdentifier);
-
-		$xmlResult = $this->connector->post($endpoint, $xmlData->asXML());
-		return $xmlResult;
-	}
-	
 	public function signReturnUrl($params = array())
 	{
 		$url = $this->returnUrl;


### PR DESCRIPTION
The new API does not support push events yet. Remove this one, as it does nothing and would just be misleading/bad code.
